### PR TITLE
Crc

### DIFF
--- a/SealHATv1.0.4/.atmelstart/AtmelStart.gpdsc
+++ b/SealHATv1.0.4/.atmelstart/AtmelStart.gpdsc
@@ -51,6 +51,7 @@
       <RTE_Components_h>#define ATMEL_START</RTE_Components_h>
       <files>
         <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/calendar.rst"/>
+        <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/crc_sync.rst"/>
         <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/evsys.rst"/>
         <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/ext_irq.rst"/>
         <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/flash.rst"/>
@@ -59,6 +60,7 @@
         <file category="doc" condition="ARMCC, GCC, IAR" name="hal/documentation/usb_device_async.rst"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_atomic.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_calendar.h"/>
+        <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_crc_sync.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_delay.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_evsys.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_ext_irq.h"/>
@@ -71,6 +73,7 @@
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_spi_m_sync.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hal_usb_device.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_core.h"/>
+        <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_crc_sync.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_delay.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_dma.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_evsys.h"/>
@@ -83,6 +86,7 @@
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_i2c_s_sync.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_init.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_irq.h"/>
+        <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_pac.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_sleep.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_spi.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_spi_async.h"/>
@@ -99,6 +103,7 @@
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_usb_host.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hal/include/hpl_user_area.h"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hal/src/hal_atomic.c"/>
+        <file category="source" condition="ARMCC, GCC, IAR" name="hal/src/hal_crc_sync.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hal/src/hal_delay.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hal/src/hal_evsys.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hal/src/hal_flash.c"/>
@@ -233,6 +238,7 @@
         <file category="header" condition="ARMCC, GCC, IAR" name="hpl/core/hpl_core_port.h"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/core/hpl_init.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/dmac/hpl_dmac.c"/>
+        <file category="source" condition="ARMCC, GCC, IAR" name="hpl/dsu/hpl_dsu.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/eic/hpl_eic.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/evsys/hpl_evsys.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/gclk/hpl_gclk.c"/>
@@ -241,6 +247,7 @@
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/nvmctrl/hpl_nvmctrl.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/osc32kctrl/hpl_osc32kctrl.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/oscctrl/hpl_oscctrl.c"/>
+        <file category="source" condition="ARMCC, GCC, IAR" name="hpl/pac/hpl_pac.c"/>
         <file category="source" condition="ARMCC, GCC, IAR" name="hpl/pm/hpl_pm.c"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hpl/pm/hpl_pm_base.h"/>
         <file category="header" condition="ARMCC, GCC, IAR" name="hpl/port/hpl_gpio_base.h"/>
@@ -277,6 +284,7 @@
         <file category="include" condition="ARMCC, GCC, IAR" name="hal/utils/include"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/core"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/dmac"/>
+        <file category="include" condition="ARMCC, GCC, IAR" name="hpl/dsu"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/eic"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/evsys"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/gclk"/>
@@ -284,6 +292,7 @@
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/nvmctrl"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/osc32kctrl"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/oscctrl"/>
+        <file category="include" condition="ARMCC, GCC, IAR" name="hpl/pac"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/pm"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/port"/>
         <file category="include" condition="ARMCC, GCC, IAR" name="hpl/rtc"/>

--- a/SealHATv1.0.4/.atmelstart/atmel_start_config.atstart
+++ b/SealHATv1.0.4/.atmelstart/atmel_start_config.atstart
@@ -2,9 +2,9 @@ format_version: '2'
 name: My Project
 versions:
   api: '1.0'
-  backend: 1.2.132
+  backend: 1.2.139
   commit: release1.2
-  content: 1.0.898
+  content: 1.0.943
   content_pack_name: unknown
   format: '2'
   frontend: 1.2.1708
@@ -23,12 +23,12 @@ middlewares:
       freertos_generate_run_time_stats: false
       freertos_max_co_routine_priorities: 2
       freertos_max_priorities: 5
-      freertos_minimal_stack_size: 64
+      freertos_minimal_stack_size: 100
       freertos_pctaskgettaskname: false
       freertos_tick_rate_hz: 1000
       freertos_timer_task_priority: 2
       freertos_timer_task_stack_depth: 64
-      freertos_total_heap_size: 4096
+      freertos_total_heap_size: 10000
       freertos_use_16_bit_ticks: false
       freertos_use_application_task_tag_functions: false
       freertos_use_co_routines: false
@@ -423,6 +423,16 @@ drivers:
       dmac_trigact_8: One trigger required for each block transfer
       dmac_trigact_9: One trigger required for each block transfer
       dmac_wrbqos: Background (no sensitive operation)
+    optional_signals: []
+    variant: null
+    clocks:
+      domain_group: null
+  CRC_0:
+    user_label: CRC_0
+    definition: Atmel:SAML21_Drivers:0.0.1::SAML21G18B-MN::DSU::driver_config_definition::CRC~28DSU~29::HAL:Driver:CRC
+    functionality: CRC
+    api: HAL:Driver:CRC
+    configuration: {}
     optional_signals: []
     variant: null
     clocks:

--- a/SealHATv1.0.4/Config/FreeRTOSConfig.h.bak
+++ b/SealHATv1.0.4/Config/FreeRTOSConfig.h.bak
@@ -32,7 +32,7 @@ void assert_triggered(const char *file, uint32_t line);
 // <i> Default: 64
 // <id> freertos_minimal_stack_size
 #ifndef configMINIMAL_STACK_SIZE
-#define configMINIMAL_STACK_SIZE ((uint16_t)100)
+#define configMINIMAL_STACK_SIZE ((uint16_t)64)
 #endif
 
 #ifndef configSUPPORT_STATIC_ALLOCATION

--- a/SealHATv1.0.4/Config/hpl_evsys_config.h
+++ b/SealHATv1.0.4/Config/hpl_evsys_config.h
@@ -1768,6 +1768,10 @@
 
 // </e>
 
+// <h>  Event User Security Attribution Settings
+
+//</h>
+
 // <h> PORT events
 // <o> Channel selection for PORT event 0
 // <0x0=>No channel output selected
@@ -1848,7 +1852,6 @@
 #ifndef CONF_CHANNEL_3
 #define CONF_CHANNEL_3 0
 #endif
-
 //</h>
 
 // <h> DMAC events
@@ -2011,7 +2014,6 @@
 #ifndef CONF_CHANNEL_11
 #define CONF_CHANNEL_11 0
 #endif
-
 //</h>
 
 // <h> TCC events
@@ -2294,7 +2296,6 @@
 #ifndef CONF_CHANNEL_25
 #define CONF_CHANNEL_25 0
 #endif
-
 //</h>
 
 // <h> TC events
@@ -2397,7 +2398,6 @@
 #ifndef CONF_CHANNEL_30
 #define CONF_CHANNEL_30 1
 #endif
-
 //</h>
 
 // <h> ADC events
@@ -2440,7 +2440,6 @@
 #ifndef CONF_CHANNEL_32
 #define CONF_CHANNEL_32 0
 #endif
-
 //</h>
 
 // <h> AC events
@@ -2483,7 +2482,6 @@
 #ifndef CONF_CHANNEL_34
 #define CONF_CHANNEL_34 0
 #endif
-
 //</h>
 
 // <h> DAC events
@@ -2526,7 +2524,6 @@
 #ifndef CONF_CHANNEL_36
 #define CONF_CHANNEL_36 0
 #endif
-
 //</h>
 
 // <h> PTC events
@@ -2549,7 +2546,6 @@
 #ifndef CONF_CHANNEL_37
 #define CONF_CHANNEL_37 0
 #endif
-
 //</h>
 
 // <h> CCL events
@@ -2632,14 +2628,12 @@
 #ifndef CONF_CHANNEL_41
 #define CONF_CHANNEL_41 0
 #endif
-
 //</h>
 
 // <h> Reserved
 #ifndef CONF_CHANNEL_42
 #define CONF_CHANNEL_42 0
 #endif
-
 //</h>
 
 // <h> MTB Events
@@ -2682,7 +2676,6 @@
 #ifndef CONF_CHANNEL_44
 #define CONF_CHANNEL_44 0
 #endif
-
 //</h>
 
 // <<< end of configuration section >>>

--- a/SealHATv1.0.4/SealHATv1.0.4.cproj
+++ b/SealHATv1.0.4/SealHATv1.0.4.cproj
@@ -305,6 +305,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -312,6 +313,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -357,6 +359,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -364,6 +367,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -393,6 +397,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -400,6 +405,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -446,6 +452,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -453,6 +460,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -506,6 +514,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -513,6 +522,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -543,6 +553,7 @@
       <Value>../hal/utils/include</Value>
       <Value>../hpl/core</Value>
       <Value>../hpl/dmac</Value>
+      <Value>../hpl/dsu</Value>
       <Value>../hpl/eic</Value>
       <Value>../hpl/evsys</Value>
       <Value>../hpl/gclk</Value>
@@ -550,6 +561,7 @@
       <Value>../hpl/nvmctrl</Value>
       <Value>../hpl/osc32kctrl</Value>
       <Value>../hpl/oscctrl</Value>
+      <Value>../hpl/pac</Value>
       <Value>../hpl/pm</Value>
       <Value>../hpl/port</Value>
       <Value>../hpl/rtc</Value>
@@ -651,6 +663,9 @@
     <Compile Include="hal\include\hal_calendar.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="hal\include\hal_crc_sync.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="hal\include\hal_delay.h">
       <SubType>compile</SubType>
     </Compile>
@@ -690,6 +705,9 @@
     <Compile Include="hal\include\hpl_core.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="hal\include\hpl_crc_sync.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="hal\include\hpl_delay.h">
       <SubType>compile</SubType>
     </Compile>
@@ -727,6 +745,9 @@
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hal\include\hpl_missing_features.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="hal\include\hpl_pac.h">
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hal\include\hpl_reset.h">
@@ -790,6 +811,9 @@
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hal\src\hal_calendar.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="hal\src\hal_crc_sync.c">
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hal\src\hal_delay.c">
@@ -885,6 +909,9 @@
     <Compile Include="hpl\dmac\hpl_dmac.c">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="hpl\dsu\hpl_dsu.c">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="hpl\eic\hpl_eic.c">
       <SubType>compile</SubType>
     </Compile>
@@ -907,6 +934,9 @@
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hpl\oscctrl\hpl_oscctrl.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="hpl\pac\hpl_pac.c">
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="hpl\pm\hpl_pm.c">
@@ -1263,12 +1293,6 @@
     <Compile Include="utilities\seal_UTIL.h">
       <SubType>compile</SubType>
     </Compile>
-    <None Include="usb\class\cdc\device\atmel_devices_cdc.cat">
-      <SubType>compile</SubType>
-    </None>
-    <None Include="usb\class\cdc\device\atmel_devices_cdc.inf">
-      <SubType>compile</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Config\" />
@@ -1283,6 +1307,7 @@
     <Folder Include="hpl\" />
     <Folder Include="hpl\core\" />
     <Folder Include="hpl\dmac\" />
+    <Folder Include="hpl\dsu\" />
     <Folder Include="hpl\eic\" />
     <Folder Include="hpl\evsys\" />
     <Folder Include="hpl\gclk\" />
@@ -1290,6 +1315,7 @@
     <Folder Include="hpl\nvmctrl\" />
     <Folder Include="hpl\osc32kctrl\" />
     <Folder Include="hpl\oscctrl\" />
+    <Folder Include="hpl\pac\" />
     <Folder Include="hpl\pm\" />
     <Folder Include="hpl\port\" />
     <Folder Include="hpl\rtc\" />
@@ -1324,6 +1350,12 @@
       <SubType>compile</SubType>
     </None>
     <None Include="Device_Startup\saml21g18b_sram.ld">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="usb\class\cdc\device\atmel_devices_cdc.cat">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="usb\class\cdc\device\atmel_devices_cdc.inf">
       <SubType>compile</SubType>
     </None>
   </ItemGroup>

--- a/SealHATv1.0.4/driver_init.c
+++ b/SealHATv1.0.4/driver_init.c
@@ -11,6 +11,7 @@
 #include <utils.h>
 #include <hal_init.h>
 
+struct crc_sync_descriptor   CRC_0;
 struct spi_m_sync_descriptor SPI_MEMORY;
 
 struct flash_descriptor FLASH_NVM;
@@ -22,6 +23,17 @@ struct i2c_m_sync_desc I2C_GPS;
 struct i2c_m_sync_desc I2C_ENV;
 
 struct i2c_m_sync_desc I2C_IMU;
+
+/**
+ * \brief CRC initialization function
+ *
+ * Enables CRC peripheral, clocks and initializes CRC driver
+ */
+void CRC_0_init(void)
+{
+	hri_mclk_set_APBBMASK_DSU_bit(MCLK);
+	crc_sync_init(&CRC_0, DSU);
+}
 
 void EXTERNAL_IRQ_init(void)
 {
@@ -303,6 +315,7 @@ void EVENT_SYS_init(void)
 	hri_gclk_write_PCHCTRL_reg(GCLK, EVSYS_GCLK_ID_0, CONF_GCLK_EVSYS_CHANNEL_0_SRC | (1 << GCLK_PCHCTRL_CHEN_Pos));
 
 	hri_mclk_set_APBDMASK_EVSYS_bit(MCLK);
+
 	event_system_init();
 }
 
@@ -592,6 +605,7 @@ void system_init(void)
 
 	gpio_set_pin_function(GPS_RESET, GPIO_PIN_FUNCTION_OFF);
 
+	CRC_0_init();
 	EXTERNAL_IRQ_init();
 
 	FLASH_NVM_init();

--- a/SealHATv1.0.4/driver_init.h
+++ b/SealHATv1.0.4/driver_init.h
@@ -21,6 +21,7 @@ extern "C" {
 #include <hal_io.h>
 #include <hal_sleep.h>
 
+#include <hal_crc_sync.h>
 #include <hal_ext_irq.h>
 
 #include <hal_flash.h>
@@ -38,6 +39,8 @@ extern "C" {
 #include <hal_evsys.h>
 
 #include "hal_usb_device.h"
+
+extern struct crc_sync_descriptor CRC_0;
 
 extern struct flash_descriptor FLASH_NVM;
 

--- a/SealHATv1.0.4/examples/driver_examples.c
+++ b/SealHATv1.0.4/examples/driver_examples.c
@@ -10,6 +10,55 @@
 #include "driver_init.h"
 #include "utils.h"
 
+/* CRC Data in flash */
+COMPILER_ALIGNED(4)
+static const uint32_t crc_datas[] = {0x00000000,
+                                     0x11111111,
+                                     0x22222222,
+                                     0x33333333,
+                                     0x44444444,
+                                     0x55555555,
+                                     0x66666666,
+                                     0x77777777,
+                                     0x88888888,
+                                     0x99999999};
+
+/**
+ * Example of using CRC_0 to Calculate CRC32 for a buffer.
+ */
+void CRC_0_example(void)
+{
+	/* The initial value used for the CRC32 calculation usually be 0xFFFFFFFF,
+	 * but can be, for example, the result of a previous CRC32 calculation if
+	 * generating a common CRC32 of separate memory blocks.
+	 */
+	uint32_t crc = 0xFFFFFFFF;
+	uint32_t crc2;
+	uint32_t ind;
+
+	crc_sync_enable(&CRC_0);
+	crc_sync_crc32(&CRC_0, (uint32_t *)crc_datas, 10, &crc);
+
+	/* The read value must be complemented to match standard CRC32
+	 * implementations or kept non-inverted if used as starting point for
+	 * subsequent CRC32 calculations.
+	 */
+	crc ^= 0xFFFFFFFF;
+
+	/* Calculate the same data with subsequent CRC32 calculations, the result
+	 * should be same as previous way.
+	 */
+	crc2 = 0xFFFFFFFF;
+	for (ind = 0; ind < 10; ind++) {
+		crc_sync_crc32(&CRC_0, (uint32_t *)&crc_datas[ind], 1, &crc2);
+	}
+	crc2 ^= 0xFFFFFFFF;
+
+	/* The calculate result should be same. */
+	while (crc != crc2)
+		;
+}
+
 static void button_on_PA19_pressed(void)
 {
 }

--- a/SealHATv1.0.4/examples/driver_examples.h
+++ b/SealHATv1.0.4/examples/driver_examples.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+void CRC_0_example(void);
+
 void EXTERNAL_IRQ_example(void);
 
 void FLASH_NVM_example(void);

--- a/SealHATv1.0.4/hal/include/hal_crc_sync.h
+++ b/SealHATv1.0.4/hal/include/hal_crc_sync.h
@@ -1,0 +1,146 @@
+/**
+ * \file
+ *
+ * \brief CRC Cyclic Redundancy Check(Sync) functionality declaration.
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef HAL_CRC_SYNC_H_INCLUDED
+#define HAL_CRC_SYNC_H_INCLUDED
+
+#include <hpl_crc_sync.h>
+#include <utils_assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup doc_driver_hal_crc_sync
+ *
+ *@{
+ */
+
+/**
+ * \brief CRC descriptor
+ */
+struct crc_sync_descriptor {
+	struct _crc_sync_device dev; /*!< CRC HPL device descriptor */
+};
+
+/**
+ * \brief Initialize CRC.
+ *
+ * This function initializes the given CRC descriptor.
+ * It checks if the given hardware is not initialized and if the given hardware
+ * is permitted to be initialized.
+ *
+ * \param[out] descr A CRC descriptor to initialize
+ * \param[in] hw The pointer to hardware instance
+ *
+ * \return Initialization status.
+ */
+int32_t crc_sync_init(struct crc_sync_descriptor *const descr, void *const hw);
+
+/**
+ * \brief Deinitialize CRC.
+ *
+ * This function deinitializes the given CRC descriptor.
+ * It checks if the given hardware is initialized and if the given hardware is
+ * permitted to be deinitialized.
+ *
+ * \param[in] descr A CRC descriptor to deinitialize
+ *
+ * \return De-initialization status.
+ */
+int32_t crc_sync_deinit(struct crc_sync_descriptor *const descr);
+
+/**
+ * \brief Enable CRC
+ *
+ * This function enables CRC by the given CRC descriptor.
+ *
+ * \param[in] descr A CRC descriptor to enable
+ *
+ * \return Enabling status.
+ */
+int32_t crc_sync_enable(struct crc_sync_descriptor *const descr);
+
+/**
+ * \brief Disable CRC
+ *
+ * This function disables CRC by the given CRC descriptor.
+ *
+ * \param[in] descr A CRC descriptor to disable
+ *
+ * \return Disabling status.
+ */
+int32_t crc_sync_disable(struct crc_sync_descriptor *const descr);
+
+/**
+ * \brief Calculate CRC32 value of the buffer
+ *
+ * This function calculates the standard CRC-32 (IEEE 802.3).
+ *
+ * \param[in] data Pointer to the input data buffer
+ * \param[in] len Length of the input data buffer
+ * \param[in,out] pcrc Pointer to the CRC value
+ *
+ * \return Calculated result.
+ */
+int32_t crc_sync_crc32(struct crc_sync_descriptor *const descr, uint32_t *const data, const uint32_t len,
+                       uint32_t *pcrc);
+
+/**
+ * \brief Calculate the CRC16 value of the buffer
+ *
+ * This function calculates CRC-16 (CCITT).
+ *
+ * \param[in] data Pointer to the input data buffer
+ * \param[in] len Length of the input data buffer
+ * \param[in,out] pcrc Pointer to the CRC value
+ *
+ * \return Calculated result.
+ */
+int32_t crc_sync_crc16(struct crc_sync_descriptor *const descr, uint16_t *const data, const uint32_t len,
+                       uint16_t *pcrc);
+
+/**
+ * \brief Retrieve the current driver version
+ *
+ * \return Current driver version.
+ */
+uint32_t crc_sync_get_version(void);
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_CRC_SYNC_H_INCLUDED */

--- a/SealHATv1.0.4/hal/include/hpl_crc_sync.h
+++ b/SealHATv1.0.4/hal/include/hpl_crc_sync.h
@@ -1,0 +1,142 @@
+/**
+ * \file
+ *
+ * \brief CRC Cyclic Redundancy Check(Sync) functionality declaration.
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef HPL_CRC_SYNC_H_INCLUDED
+#define HPL_CRC_SYNC_H_INCLUDED
+
+#include <compiler.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup hpl__crc__sync CRC Sync Driver
+ *
+ * \section crc_rev Revision History
+ * - v0.0.0.1 Initial Commit
+ *
+ *@{
+ */
+
+/**
+ * \brief CRC Device
+ */
+struct _crc_sync_device {
+	void *hw; /*!< Hardware module instance handler */
+};
+
+/**
+ * \brief Initialize CRC.
+ *
+ * \param[in] device The pointer to device instance
+ * \param[in] hw The pointer to hardware instance
+ *
+ * \return Initialization status.
+ * \retval -1 Passed parameters were invalid or the CRC is already initialized
+ * \retval 0 The initialization is completed successfully
+ */
+int32_t _crc_sync_init(struct _crc_sync_device *const device, void *const hw);
+
+/**
+ * \brief Deinitialize CRC.
+ *
+ * \param[in] device The pointer to device instance
+ *
+ * \return De-initialization status.
+ * \retval -1 Passed parameters were invalid or the CRC is not initialized
+ * \retval 0 The de-initialization is completed successfully
+ */
+int32_t _crc_sync_deinit(struct _crc_sync_device *const device);
+
+/**
+ * \brief Enable CRC
+ *
+ * \param[in] device The pointer to device instance
+ *
+ * \return Enabling status.
+ * \retval -1 Passed parameters were invalid
+ * \retval 0 The enable procedure is completed successfully
+ */
+int32_t _crc_sync_enable(struct _crc_sync_device *const device);
+
+/**
+ * \brief Disable CRC
+ *
+ * \param[in] device The pointer to device instance
+ *
+ * \return Disabling status.
+ * \retval -1 Passed parameters were invalid
+ * \retval 0 The disable procedure is completed successfully
+ */
+int32_t _crc_sync_disable(struct _crc_sync_device *const device);
+
+/**
+ * \brief Calculate CRC value of the buffer
+ *
+ * \param[in] device The pointer to device instance
+ * \param[in] data Pointer to the input data buffer
+ * \param[in] len Length of the input data buffer
+ * \param[in,out] pcrc Pointer to the CRC value
+ *
+ * \return Calculate result.
+ * \retval -1 Passed parameters were invalid or hardware error occurs.
+ * \retval 0 The CRC calculate success.
+ */
+int32_t _crc_sync_crc32(struct _crc_sync_device *const device, uint32_t *const data, const uint32_t len,
+                        uint32_t *pcrc);
+
+/**
+ * \brief Compute CRC16 value of the buffer
+ *
+ * This function calculate CRC-16 (CCITT)
+ *
+ * \param[in] device The pointer to device instance
+ * \param[in] data Pointer to the input data buffer
+ * \param[in] len Length of the input data buffer
+ * \param[in,out] pcrc Pointer to the CRC value
+ *
+ * \return Calculate result.
+ * \retval -1 Passed parameters were invalid or hardware error occurs.
+ * \retval 0 The CRC calculate success.
+ */
+int32_t _crc_sync_crc16(struct _crc_sync_device *const device, uint16_t *const data, const uint32_t len,
+                        uint16_t *pcrc);
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HPL_CRC_SYNC_H_INCLUDED */

--- a/SealHATv1.0.4/hal/include/hpl_pac.h
+++ b/SealHATv1.0.4/hal/include/hpl_pac.h
@@ -1,0 +1,78 @@
+/**
+ * \file
+ *
+ * \brief PAC related functionality declaration.
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+#ifndef _HPL_PAC_H_INCLUDED
+#define _HPL_PAC_H_INCLUDED
+
+#include <compiler.h>
+#include "hpl_irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Enable write protect for the given hardware module
+ *
+ * This function enables write protect for the given hardware module.
+ * For an overview of available PAC and hardware modules see datasheet.
+ *
+ * \param[in] module A hardware module to enable write protect for
+ */
+int32_t _periph_lock(const void *const module);
+
+/**
+ * \brief Disable write protect for the given hardware module
+ *
+ * This function disables write protect for the given hardware module.
+ * For an overview of available PAC and hardware modules see datasheet.
+ *
+ * \param[in] module A hardware module to disable clock for
+ */
+int32_t _periph_unlock(const void *const module);
+
+/**
+ * \brief Get write protect state for the given hardware module
+ *
+ * This function get write protect state for the given hardware module.
+ * For an overview of available PAC and hardware modules see datasheet.
+ *
+ * \param[in] module A hardware module to disable clock for
+ * \param[out] state The pointer to write protect state for specified module
+ */
+int32_t _periph_get_lock_state(const void *const module, bool *const state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HPL_PAC_H_INCLUDED */

--- a/SealHATv1.0.4/hal/src/hal_crc_sync.c
+++ b/SealHATv1.0.4/hal/src/hal_crc_sync.c
@@ -1,0 +1,105 @@
+/**
+ * \file
+ *
+ * \brief CRC Cyclic Redundancy Check(Sync) functionality declaration.
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#include <hal_crc_sync.h>
+
+#define DRIVER_VERSION 0x00000001u
+
+/**
+ * \brief Initialize CRC.
+ */
+int32_t crc_sync_init(struct crc_sync_descriptor *const descr, void *const hw)
+{
+	ASSERT(descr && hw);
+
+	return _crc_sync_init(&descr->dev, hw);
+}
+
+/**
+ * \brief Deinitialize CRC.
+ */
+int32_t crc_sync_deinit(struct crc_sync_descriptor *const descr)
+{
+	ASSERT(descr);
+
+	return _crc_sync_deinit(&descr->dev);
+}
+
+/**
+ * \brief Enable CRC
+ */
+int32_t crc_sync_enable(struct crc_sync_descriptor *const descr)
+{
+	ASSERT(descr);
+
+	return _crc_sync_enable(&descr->dev);
+}
+
+/**
+ * \brief Disable CRC
+ */
+int32_t crc_sync_disable(struct crc_sync_descriptor *const descr)
+{
+	ASSERT(descr);
+
+	return _crc_sync_disable(&descr->dev);
+}
+/**
+ * \brief Calculate CRC32 value of the buffer
+ */
+int32_t crc_sync_crc32(struct crc_sync_descriptor *const descr, uint32_t *const data, const uint32_t len,
+                       uint32_t *pcrc)
+{
+	ASSERT(descr && data && len && pcrc);
+
+	return _crc_sync_crc32(&descr->dev, data, len, pcrc);
+}
+
+/**
+ * \brief Calculate CRC16 value of the buffer
+ */
+int32_t crc_sync_crc16(struct crc_sync_descriptor *const descr, uint16_t *const data, const uint32_t len,
+                       uint16_t *pcrc)
+{
+	ASSERT(descr && data && len && pcrc);
+
+	return _crc_sync_crc16(&descr->dev, data, len, pcrc);
+}
+
+/**
+ * \brief Retrieve the current driver version
+ */
+uint32_t crc_sync_get_version(void)
+{
+	return DRIVER_VERSION;
+}

--- a/SealHATv1.0.4/hpl/dsu/hpl_dsu.c
+++ b/SealHATv1.0.4/hpl/dsu/hpl_dsu.c
@@ -1,0 +1,127 @@
+/**
+ * \file
+ *
+ * \brief Device Service Unit
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#include <compiler.h>
+#include <hpl_pac.h>
+#include <hpl_crc_sync.h>
+#include <utils_assert.h>
+#include <err_codes.h>
+
+/**
+ * \brief Initialize CRC.
+ */
+int32_t _crc_sync_init(struct _crc_sync_device *const device, void *const hw)
+{
+	device->hw = hw;
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief De-initialize CRC.
+ */
+int32_t _crc_sync_deinit(struct _crc_sync_device *const device)
+{
+	device->hw = NULL;
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief Enable CRC
+ */
+int32_t _crc_sync_enable(struct _crc_sync_device *const device)
+{
+	(void)device;
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief Disable CRC
+ */
+int32_t _crc_sync_disable(struct _crc_sync_device *const device)
+{
+	(void)device;
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief Calculate CRC value of the buffer
+ */
+int32_t _crc_sync_crc32(struct _crc_sync_device *const device, uint32_t *const data, const uint32_t len, uint32_t *pcrc)
+{
+	int32_t rc = ERR_NONE;
+	if (((uint32_t)data) & 0x00000003) {
+		/* Address must be align with 4 bytes, refer to datasheet */
+		return ERR_INVALID_ARG;
+	}
+
+	CRITICAL_SECTION_ENTER()
+	/* Disable write-protected by PAC1->DSU before write DSU registers */
+	_periph_unlock(device->hw);
+
+	hri_dsu_write_ADDR_reg(device->hw, (uint32_t)data);
+	hri_dsu_write_LENGTH_LENGTH_bf(device->hw, len);
+	hri_dsu_write_DATA_reg(device->hw, *pcrc);
+	hri_dsu_write_CTRL_reg(device->hw, DSU_CTRL_CRC);
+
+	while (hri_dsu_get_STATUSA_DONE_bit(device->hw) == 0) {
+	}
+
+	if (hri_dsu_get_STATUSA_BERR_bit(device->hw)) {
+		hri_dsu_clear_STATUSA_BERR_bit(device->hw);
+		hri_dsu_clear_STATUSA_DONE_bit(device->hw);
+		rc = ERR_IO;
+	} else {
+		*pcrc = (uint32_t)hri_dsu_read_DATA_reg(device->hw);
+	}
+	hri_dsu_clear_STATUSA_DONE_bit(device->hw);
+
+	/* Restore write-protected of PAC->DSU */
+	_periph_lock(device->hw);
+
+	CRITICAL_SECTION_LEAVE()
+
+	return rc;
+}
+
+/**
+ * \brief Compute CRC16 value of the buffer
+ */
+int32_t _crc_sync_crc16(struct _crc_sync_device *const device, uint16_t *const data, const uint32_t len, uint16_t *pcrc)
+{
+	(void)device, (void)data, (void)len, (void)pcrc;
+	return ERR_UNSUPPORTED_OP;
+}

--- a/SealHATv1.0.4/hpl/pac/hpl_pac.c
+++ b/SealHATv1.0.4/hpl/pac/hpl_pac.c
@@ -1,0 +1,128 @@
+
+/**
+ * \file
+ *
+ * \brief SAM Peripheral Access Controller
+ *
+ * Copyright (c) 2015-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#include <compiler.h>
+#include <utils_assert.h>
+#include <hpl_pac.h>
+
+static uint32_t _pac_get_peripheral_id(const void *const module)
+{
+	uint32_t peripheral = 10;
+
+	if (((uint32_t)module & (uint32_t)HPB1_ADDR) == (uint32_t)HPB1_ADDR) {
+		peripheral = 13;
+	}
+
+	peripheral = (((uint32_t)module & 0x0F000000) >> 24) * 32 + (((uint32_t)module & 0x000fff00) >> peripheral);
+
+	return peripheral;
+}
+
+/**
+ * \brief Enable write protect for the given hardware module
+ */
+int32_t _periph_lock(const void *const module)
+{
+	ASSERT((((uint32_t)module) > (uint32_t)HPB0_ADDR));
+
+	uint32_t peripheral;
+	int32_t  timeout = 1000;
+	bool     stat;
+
+	peripheral = _pac_get_peripheral_id(module);
+
+	hri_pac_write_WRCTRL_reg(PAC, PAC_WRCTRL_PERID(peripheral) | PAC_WRCTRL_KEY_SET);
+
+	do {
+		_periph_get_lock_state(module, &stat);
+	} while (!stat && timeout--);
+
+	if (timeout < 0) {
+		return ERR_TIMEOUT;
+	}
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief Disable write protect for the given hardware module
+ */
+int32_t _periph_unlock(const void *const module)
+{
+	ASSERT((((uint32_t)module) > (uint32_t)HPB0_ADDR));
+
+	uint32_t peripheral;
+	int32_t  timeout = 1000;
+	bool     stat;
+
+	peripheral = _pac_get_peripheral_id(module);
+
+	hri_pac_write_WRCTRL_reg(PAC, PAC_WRCTRL_PERID(peripheral) | PAC_WRCTRL_KEY_CLR);
+
+	do {
+		_periph_get_lock_state(module, &stat);
+	} while (stat && timeout--);
+
+	if (timeout < 0) {
+		return ERR_TIMEOUT;
+	}
+
+	return ERR_NONE;
+}
+
+/**
+ * \brief Get write protect for the given hardware module
+ */
+int32_t _periph_get_lock_state(const void *const module, bool *const state)
+{
+	ASSERT((((uint32_t)module) > (uint32_t)HPB0_ADDR));
+
+	uint32_t peripheral;
+
+	peripheral = _pac_get_peripheral_id(module) & 0x1F;
+
+	if (((uint32_t)module) < (uint32_t)HPB1_ADDR) {
+		*state = hri_pac_get_STATUSA_reg(PAC, 1 << peripheral);
+	} else if (((uint32_t)module) < (uint32_t)HPB2_ADDR) {
+		*state = hri_pac_get_STATUSB_reg(PAC, 1 << peripheral);
+	} else if (((uint32_t)module) < (uint32_t)HPB3_ADDR) {
+		*state = hri_pac_get_STATUSC_reg(PAC, 1 << peripheral);
+	} else if (((uint32_t)module) < (uint32_t)HPB4_ADDR) {
+		*state = hri_pac_get_STATUSD_reg(PAC, 1 << peripheral);
+	} else {
+		*state = hri_pac_get_STATUSE_reg(PAC, 1 << peripheral);
+	}
+
+	return ERR_NONE;
+}

--- a/SealHATv1.0.4/hpl/usb/hpl_usb.c
+++ b/SealHATv1.0.4/hpl/usb/hpl_usb.c
@@ -1506,8 +1506,6 @@ int32_t _usb_d_dev_enable(void)
 
 	NVIC_EnableIRQ(USB_IRQn);
 
-    volatile int32_t prio = NVIC_GetPriority(USB_IRQn);
-
 	hri_usbdevice_set_INTEN_reg(hw,
 	                            USB_DEVICE_INTENSET_SOF | USB_DEVICE_INTENSET_EORST | USB_DEVICE_INTENSET_RAMACER
 	                                | USB_D_SUSPEND_INT_FLAGS);

--- a/SealHATv1.0.4/seal_Types.h
+++ b/SealHATv1.0.4/seal_Types.h
@@ -10,7 +10,8 @@
 
 #define SEAL_HAT_VERSION        (1.0)
 
-#define MSG_START_SYM           (0xADDE)
+#define PAGE_SIZE_EXTRA         (2176)              /* Maximum NAND Flash page size (*including* extra space) */
+#define PAGE_SIZE_LESS          (2048)              /* Maximum NAND Flash page size (*excluding* extra space) */
 
 /** Sensor types */
 typedef enum {
@@ -52,6 +53,8 @@ typedef enum {
     DEVICE_ERR_MASK             = 0x0F
 } DEVICE_ERR_CODES_t;
 
+#define MSG_START_SYM           (0xADDE)
+
 /** Header for data packets from the device **/
 typedef struct __attribute__((__packed__)){
     uint16_t startSym;    // symbol to indicate start of packet
@@ -60,5 +63,14 @@ typedef struct __attribute__((__packed__)){
     uint16_t msTime;    // timestamp ms part
     uint16_t size;		// size of data packet to follow in bytes
 } DATA_HEADER_t;
+
+#define USB_PACKET_START_SYM           (0xCAFED00D)
+
+/** Packet that gets sent over USB to the host computer **/
+typedef struct __attribute__((__packed__)){
+    uint32_t startSymbol;           // start symbol for the data transmission
+    uint8_t  data[PAGE_SIZE_LESS];  // one page of data from flash
+    uint32_t crc;                   // crc32 of the DATA (not the start symbol) using IEEE CRC32 polynomial
+} DATA_TRANSMISSION_t;
 
 #endif /* SEAL_TYPES_H_ */

--- a/SealHATv1.0.4/tasks/seal_CTRL.h
+++ b/SealHATv1.0.4/tasks/seal_CTRL.h
@@ -9,8 +9,8 @@
 #ifndef SEAL_MSG_H_
 #define SEAL_MSG_H_
 
-#define MSG_STACK_SIZE                  (3000 / sizeof(portSTACK_TYPE))
-#define MSG_TASK_PRI                    (tskIDLE_PRIORITY + 1)
+#define CTRL_STACK_SIZE                 (4000 / sizeof(portSTACK_TYPE))
+#define CTRL_TASK_PRI                   (tskIDLE_PRIORITY + 1)
 #define DATA_QUEUE_LENGTH               (2000)
 
 #define CONFIG_BLOCK_BASE_ADDR          (0x3F840)   /* First writable page address of on-chip EEPROM. */
@@ -20,9 +20,9 @@ typedef enum {
     // System state alerts
     EVENT_VBUS          = 0x00000001, // indicated the current VBUS level, use USB API to check USB state
     EVENT_LOW_BATTERY   = 0x00000002, // Indicates the battery has reached a critically low level according to settings
-    EVENT_SYS_1         = 0x00000004,
-    EVENT_SYS_2         = 0x00000008,
-    EVENT_SYS_3         = 0x00000010,
+    EVENT_LOGTOFLASH    = 0x00000004, // This bit indicates that the system should be logging data to the flash memory
+    EVENT_LOGTOUSB      = 0x00000008, // This bit indicates that the device should be streaming data over USB
+    EVENT_DEBUG         = 0x00000010, // This bit indicates that the device is in debug mode. this overrides the other modes.
     EVENT_SYS_4         = 0x00000020,
     EVENT_SYS_5         = 0x00000040,
     EVENT_SYS_6         = 0x00000080,
@@ -30,16 +30,19 @@ typedef enum {
 
     // IMU events. names assume pin 1 of the IMU is in the upper right
     // Consumers of these flags are responsible for clearing them
-    EVENT_MOTION_SHIFT   = 8,
-    EVENT_MASK_IMU       = 0x0000FF00, // mask for watching the IMU bits
-    EVENT_MOTION_XLOW    = 0x00000100,
-    EVENT_MOTION_XHI     = 0x00000200,
-    EVENT_MOTION_YLOW    = 0x00000400,
-    EVENT_MOTION_YHI     = 0x00000800,
-    EVENT_MOTION_ZLOW    = 0x00001000,
-    EVENT_MOTION_ZHI     = 0x00002000,
-    EVENT_IMU_ACTIVE     = 0x00004000,
-    EVENT_IMU_IDLE       = 0x00008000,
+    EVENT_MOTION_SHIFT  = 8,          // number of bits to shift the LSM303 motion alerts register to match these bits
+    EVENT_MASK_IMU      = 0x0000FF00, // mask for watching the IMU bits
+    EVENT_MASK_IMU_X    = 0x00000300, // mask for isolating the IMU X axis
+    EVENT_MASK_IMU_Y    = 0x00000C00, // mask for isolating the IMU X axis
+    EVENT_MASK_IMU_Z    = 0x00003000, // mask for isolating the IMU X axis
+    EVENT_MOTION_XLOW   = 0x00000100,
+    EVENT_MOTION_XHI    = 0x00000200,
+    EVENT_MOTION_YLOW   = 0x00000400,
+    EVENT_MOTION_YHI    = 0x00000800,
+    EVENT_MOTION_ZLOW   = 0x00001000,
+    EVENT_MOTION_ZHI    = 0x00002000,
+    EVENT_IMU_ACTIVE    = 0x00004000,
+    EVENT_IMU_IDLE      = 0x00008000,
 
     EVENT_UNUSED_7      = 0x00010000,
     EVENT_UNUSED_8      = 0x00020000,

--- a/SealHATv1.0.4/tasks/seal_CTRL.h
+++ b/SealHATv1.0.4/tasks/seal_CTRL.h
@@ -11,7 +11,7 @@
 
 #define CTRL_STACK_SIZE                 (4000 / sizeof(portSTACK_TYPE))
 #define CTRL_TASK_PRI                   (tskIDLE_PRIORITY + 1)
-#define DATA_QUEUE_LENGTH               (2000)
+#define DATA_QUEUE_LENGTH               (3000)
 
 #define CONFIG_BLOCK_BASE_ADDR          (0x3F840)   /* First writable page address of on-chip EEPROM. */
 


### PR DESCRIPTION
CRC module added in START project.
The CRC is very simple to use, and is available as CRC32 and CRC16.
just make sure the you feed it a buffer of 16/32 bit integers, and the size is based on that data type (not bytes).


New struct for sending over USB too, with buffer the size of a flash page a start symbol and a CRC32.